### PR TITLE
Ensure inventory patch runs after other mods

### DIFF
--- a/Source/UseInventory.cs
+++ b/Source/UseInventory.cs
@@ -16,7 +16,8 @@ namespace Build_From_Inventory
 	{
 		//GenClosest::ClosestThingReachable
 		//protected Job ResourceDeliverJobFor(Pawn pawn, IConstructible c, bool canRemoveExistingFloorUnderNearbyNeeders = true)
-		public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+                [HarmonyPriority(Priority.Last)]
+                public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
 		{
 			instructions = Transpilers.MethodReplacer(instructions,
 				AccessTools.Method(typeof(GenClosest), nameof(GenClosest.ClosestThingReachable)),


### PR DESCRIPTION
## Summary
- ensure the inventory transpiler runs after other mods to prevent conflicts

## Testing
- `dotnet build Source/Build_From_Inventory.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688dabdcbd908324a5429a7a44ad6b4f